### PR TITLE
left_joins_values should not be nil

### DIFF
--- a/lib/left_joins.rb
+++ b/lib/left_joins.rb
@@ -12,7 +12,11 @@ module ActiveRecord::QueryMethods
     # ----------------------------------------------------------------
     # ● Storing left joins values into @left_outer_joins_values
     # ----------------------------------------------------------------
-    attr_accessor :left_outer_joins_values
+    attr_writer :left_outer_joins_values
+    def left_outer_joins_values
+      @left_outer_joins_values ||= []
+    end
+
     def left_outer_joins(*args)
       check_if_method_has_arguments!(:left_outer_joins, args)
 
@@ -24,7 +28,7 @@ module ActiveRecord::QueryMethods
     end
 
     def left_outer_joins!(*args)
-      (@left_outer_joins_values ||= []) << args
+      left_outer_joins_values.concat(args)
       self
     end
 
@@ -35,7 +39,7 @@ module ActiveRecord::QueryMethods
     alias_method :build_arel_without_outer_joins, :build_arel
     def build_arel(*args)
       arel = build_arel_without_outer_joins(*args)
-      build_left_outer_joins(arel, @left_outer_joins_values.flatten) if @left_outer_joins_values
+      build_left_outer_joins(arel, @left_outer_joins_values) if @left_outer_joins_values
       return arel
     end
 

--- a/test/left_outer_joins_values_test.rb
+++ b/test/left_outer_joins_values_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class LeftOuterJoinsValuesTest < Minitest::Test
+  def setup
+  end
+
+  def test_empty_relation
+    assert_equal [], User.where('').left_outer_joins_values
+    assert_equal [], User.where('').joins_values
+  end
+
+  def test_joins
+    assert_equal [], User.joins(:posts).left_outer_joins_values
+    assert_equal [:posts], User.joins(:posts).joins_values
+  end
+
+  def test_left_joins
+    assert_equal [:posts], User.left_joins(:posts).left_outer_joins_values
+    assert_equal [], User.left_joins(:posts).joins_values
+  end
+end


### PR DESCRIPTION
should be empty array if there is no left_joins values
Just like what `joins_values` behaves.
And `left_joins_values` is expected to be array in Rails source code.
https://github.com/rails/rails/blob/v5.2.3/activerecord/lib/active_record/relation.rb#L542-L544