### PR TITLE
Fix: AR ~4.2 counter_cache broken in 1.0.6

### DIFF
--- a/lib/left_joins.rb
+++ b/lib/left_joins.rb
@@ -180,6 +180,7 @@ module ActiveRecord
         end
 
         bvs = LeftJoins.bind_values_of(self) + bind_values
+        bvs = LeftJoins.bind_values_of(arel) + bind_values
         @klass.connection.update stmt, 'SQL', bvs
       end
     end

--- a/lib/left_joins.rb
+++ b/lib/left_joins.rb
@@ -8,9 +8,10 @@ module LeftJoins
   require 'left_joins_for_rails_3' if IS_RAILS3_FLAG
 
   class << self
-    def bind_values_of(relation)
-      return relation.bound_attributes if relation.respond_to?(:bound_attributes) # For Rails 5.0, 5.1, 5.2
-      return relation.bind_values # For Rails 4.2
+    def bind_values_of(arel)
+      return arel.bound_attributes if arel.respond_to?(:bound_attributes) # For Rails 5.0, 5.1, 5.2
+      return arel.bind_values if arel.respond_to?(:bind_values) # For Rails 4.2
+      return [] # For Rails 3.2
     end
   end
 end

--- a/test/counter_cache_test.rb
+++ b/test/counter_cache_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class CounterCacheTest < Minitest::Test
+  def test_left_joins
+    organization = Organization.create name: 'Organization 01'
+    membership   = Membership.create name: 'A Memberships', organization: organization
+
+    assert_equal organization.memberships.first, membership
+  end
+end

--- a/test/lib/models/membership.rb
+++ b/test/lib/models/membership.rb
@@ -1,0 +1,3 @@
+class Membership < ActiveRecord::Base
+  belongs_to :organization, counter_cache: :memberships_count
+end

--- a/test/lib/models/organization.rb
+++ b/test/lib/models/organization.rb
@@ -1,0 +1,3 @@
+class Organization < ActiveRecord::Base
+  has_many :memberships, dependent: :destroy
+end

--- a/test/lib/models/post.rb
+++ b/test/lib/models/post.rb
@@ -1,0 +1,4 @@
+class Post < ActiveRecord::Base
+  belongs_to :user
+  has_many :post_comments
+end

--- a/test/lib/models/post_comment.rb
+++ b/test/lib/models/post_comment.rb
@@ -1,0 +1,3 @@
+class PostComment < ActiveRecord::Base
+  belongs_to :post
+end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -1,0 +1,18 @@
+class User < ActiveRecord::Base
+  serialize :serialized_attribute, Hash
+  has_many :posts
+  if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.0.0')
+    has_many :posts_with_comments2, class_name: 'Post'
+    has_many :posts_and_comments2 , class_name: 'Post'
+    def posts_with_comments
+      posts_with_comments2.joins(:post_comments)
+    end
+
+    def posts_and_comments
+      posts_and_comments2.left_joins(:post_comments)
+    end
+  else
+    has_many :posts_with_comments, ->{ joins(:post_comments) }, class_name: 'Post'
+    has_many :posts_and_comments , ->{ left_joins(:post_comments) }, class_name: 'Post'
+  end
+end

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -18,35 +18,21 @@ ActiveRecord::Schema.define do
     t.integer :post_id
     t.string :comment
   end
-end
 
-class User < ActiveRecord::Base
-  serialize :serialized_attribute, Hash
-  has_many :posts
-  if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.0.0')
-    has_many :posts_with_comments2, class_name: 'Post'
-    has_many :posts_and_comments2 , class_name: 'Post'
-    def posts_with_comments
-      posts_with_comments2.joins(:post_comments)
-    end
+  create_table :organizations, force: true do |t|
+    t.string  :name
+    t.integer :memberships_count, default: 0
+    t.timestamps
+  end
 
-    def posts_and_comments
-      posts_and_comments2.left_joins(:post_comments)
-    end
-  else
-    has_many :posts_with_comments, ->{ joins(:post_comments) }, class_name: 'Post'
-    has_many :posts_and_comments , ->{ left_joins(:post_comments) }, class_name: 'Post'
+  create_table :memberships, force: true do |t|
+    t.string  :name
+    t.references :organization
+    t.timestamps
   end
 end
 
-class Post < ActiveRecord::Base
-  belongs_to :user
-  has_many :post_comments
-end
-
-class PostComment < ActiveRecord::Base
-  belongs_to :post
-end
+ActiveSupport::Dependencies.autoload_paths << File.expand_path('../models/', __FILE__)
 
 users = User.create([
   {:name => 'John1', :email => 'john1@example.com'},

--- a/test/lib/sqlite3_connection.rb
+++ b/test/lib/sqlite3_connection.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+ActiveRecord::Base.establish_connection(
+  "adapter"  => "sqlite3",
+  "database" => ":memory:"
+)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,8 +7,5 @@ require 'left_joins'
 require 'minitest/autorun'
 Minitest::Test = MiniTest::Unit::TestCase unless defined? Minitest::Test
 
-ActiveRecord::Base.establish_connection(
-  "adapter"  => "sqlite3",
-  "database" => ":memory:"
-)
-require 'seeds'
+require 'lib/sqlite3_connection'
+require 'lib/seeds'


### PR DESCRIPTION
Fix #13 

The bug is caused by #12 where I overwriting `update_all` method. It's not a good idea since `update_all` methods has lots of changes among rails 3, 4, and 5.

What #12 wants to do is replace `join_values.any?` with `has_join_values?`
See:
https://github.com/rails/rails/blob/v4.2.11.1/activerecord/lib/active_record/relation.rb#L336
https://github.com/rails/rails/blob/v5.2.3/activerecord/lib/active_record/relation.rb#L328

In this PR, I use singleton method to patch it instead of overwriting the whole `update_all` method.