### PR TITLE
Fix: missing distinct_value if using `left_joins` after `distinct`

### DIFF
--- a/lib/left_joins.rb
+++ b/lib/left_joins.rb
@@ -35,7 +35,7 @@ module ActiveRecord::QueryMethods
 
       args.compact!
       args.flatten!
-      self.distinct_value = false
+      self.distinct_value = false if self.distinct_value == nil
 
       return (LeftJoins::IS_RAILS3_FLAG ? clone : spawn).left_outer_joins!(*args)
     end

--- a/test/left_joins_test.rb
+++ b/test/left_joins_test.rb
@@ -16,11 +16,16 @@ class LeftJoinsTest < Minitest::Test
   end
 
   def test_left_joins_with_distinct
-    assert_equal 3, User.joins(:posts).distinct.count
-    assert_equal 3, User.distinct.joins(:posts).count
+    if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('4')
+      assert_equal 3, User.joins(:posts).distinct.count
+      assert_equal 3, User.distinct.joins(:posts).count
 
-    assert_equal 4, User.left_joins(:posts).distinct.count
-    assert_equal 4, User.distinct.left_joins(:posts).count
+      assert_equal 4, User.left_joins(:posts).distinct.count
+      assert_equal 4, User.distinct.left_joins(:posts).count
+    else
+      assert_equal 3, User.joins(:posts).count(:id, distinct: true)
+      assert_equal 4, User.left_joins(:posts).count(:id, distinct: true)
+    end
   end
 
   def test_left_joins_on_has_many_association

--- a/test/left_joins_test.rb
+++ b/test/left_joins_test.rb
@@ -15,6 +15,14 @@ class LeftJoinsTest < Minitest::Test
     assert_equal User.left_outer_joins(:posts).count, User.left_joins(:posts).count
   end
 
+  def test_left_joins_with_distinct
+    assert_equal 3, User.joins(:posts).distinct.count
+    assert_equal 3, User.distinct.joins(:posts).count
+
+    assert_equal 4, User.left_joins(:posts).distinct.count
+    assert_equal 4, User.distinct.left_joins(:posts).count
+  end
+
   def test_left_joins_on_has_many_association
     assert_equal [
       "John1's post3",


### PR DESCRIPTION
### Expected
```rb
User.distinct.left_joins(:posts).count
# SELECT DISTINCT COUNT(DISTINCT `users`.`id`) FROM `users` LEFT OUTER JOIN `posts` ON `posts`.`user_id` = `users`.`id`
```

### Actual Behavior
```rb
User.distinct.left_joins(:posts).count
# SELECT COUNT(*) FROM `users` LEFT OUTER JOIN `posts` ON `posts`.`user_id` = `users`.`id`
```